### PR TITLE
Exception raised when file not found.

### DIFF
--- a/app/blog.rb
+++ b/app/blog.rb
@@ -9,12 +9,12 @@ require 'pry'
 
 module Blossome 
   class Blog < Sinatra::Base
-    register Sinatra::Partial    
+    register Sinatra::Partial
 
-  set :partial_template_engine, :haml    
-  set :environment, :develpment 
-  set :show_exceptions, :true
   @@config = Blossome::Config.new #loads ./config/config.yaml
+    set :partial_template_engine, :haml
+    set :environment, ENV["RACK_ENV"] || "test"
+    set :show_exceptions, ENV["RACK_ENV"] == "development"
 
 
   ##

--- a/app/config.rb
+++ b/app/config.rb
@@ -1,7 +1,7 @@
 require 'yaml'
 module Blossome
   class Config
-    attr_accessor :title, :description, :keywords  
+    attr_accessor :title, :description, :keywords
     def initialize
       config = YAML.load_file('./config/config.yml')
       @title = config["blog"]["title"]

--- a/app/post.rb
+++ b/app/post.rb
@@ -31,6 +31,7 @@ module Blossome
     def self.split(name)
       
       name += ".md" if !name.end_with?(".md")
+      begin
       post = File.new("./posts/#{name}").readlines
 
       yaml_separator = post.grep(/\-\n/)[1] #finds the second ocurrance of "--*"
@@ -38,12 +39,21 @@ module Blossome
 
       yaml = post[1..yaml_ends_index].join # 2nd line to were it ends
       markdown = post[yaml_ends_index+1..-1].join #were YAML ends + 1 to the end
+      rescue => e
+       if e.class == Errno::ENOENT
+           #File not found => Send 404 Error
+            return self.split("../config/error404.md")
+          else  #Send 500 Error
+            return self.split("../config/error500.md")
+        end
+      end
     
       return yaml, markdown
     end
 
 
-    def date_to_time(date)  
+    def date_to_time(date)
+      return if date.nil?        # Don't show time
       parts = date.gsub(",","").split(" ")
       #Time.new(year, month, date). Month has to be a 3 digits of the month
       time = Time.new(parts[2].to_i, parts[0][0..2], parts[1].to_i)

--- a/config/error404.md
+++ b/config/error404.md
@@ -1,0 +1,11 @@
+-----------------------
+
+title: "The page you were looking for doesn't exist (404)"
+description: "Page not found"
+keywords: ""
+
+-----------------------
+
+The page you were looking for doesn't exist.
+You may have mistyped the address or the page may have moved.
+

--- a/config/error500.md
+++ b/config/error500.md
@@ -1,0 +1,10 @@
+-----------------------
+
+title: "We're sorry, but something went wrong (500)"
+description: "Internal Server Error"
+keywords: ""
+
+-----------------------
+
+We're sorry, but something went wrong.
+


### PR DESCRIPTION
A exception is raised if a post is not found exposing the server variable and path to the public.

Show_Exceptions is disabled in Production mode
Show Error404/500 page instead of crashing.
